### PR TITLE
[Sikkerhet] Oppdaterer catalog-info.yaml med komponent

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+# nonk8s
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: argocd-lab-appdrift
+  tags: [internal]
+  links:
+    - url: https://github.com/kartverket/argocd-lab-appdrift
+      title: argocd-lab-appdrift på GitHub
+spec:
+  type: ops
+  lifecycle: production
+  owner: matrikkel
+  system: matrikkel
+  dependsOn: []
+  providesApis: []


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Oppretter følgende på komponenten:

- `owner`: `matrikkel`
- `type`: `ops`
- `lifecycle`: `production`
- `visibility` (`tags`): `internal`

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.